### PR TITLE
enhance config command to support backing up configuration files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,10 @@ name = "bk"
 path = "src/bin/main.rs"
 
 [profile.release]
-lto = true
 opt-level = 3
+strip = "symbols"
+lto = "fat"
+panic = "abort"
+debug-assertions = false
+incremental = false
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # hbackup
 
+[![Build status](https://github.com/asthetik/hbackup/workflows/build/badge.svg)](https://github.com/asthetik/hbackup/actions)
 [![Crates.io](https://img.shields.io/crates/v/hbackup.svg)](https://crates.io/crates/hbackup)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://opensource.org/licenses/MIT)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ hbackup is a sample, high-performance, cross-platform backup tool written in Rus
 ### 1. Install
 
 ```sh
-cargo install hbackup --version 0.1.0
+cargo install hbackup
 ```
 
 ### 2. Add a backup task

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,6 @@
 # hbackup
 
+[![Build status](https://github.com/asthetik/hbackup/workflows/build/badge.svg)](https://github.com/asthetik/hbackup/actions)
 [![Crates.io](https://img.shields.io/crates/v/hbackup.svg)](https://crates.io/crates/hbackup)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](https://opensource.org/licenses/MIT)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@ hbackup 是一个用 Rust 编写的高性能跨平台备份工具。它以快速
 ### 1. 安装
 
 ```sh
-cargo install hbackup --version 0.1.0
+cargo install hbackup
 ```
 
 ### 2. 添加一个备份任务

--- a/src/application.rs
+++ b/src/application.rs
@@ -117,20 +117,26 @@ impl Application {
     }
 }
 
+const PKG_NAME: &str = env!("CARGO_PKG_NAME");
+
 /// Returns the absolute path to the configuration file.
 pub fn config_file() -> PathBuf {
-    let mut file = if cfg!(target_os = "macos") {
+    config_dir().join(format!("{PKG_NAME}.json"))
+}
+
+pub fn backup_config_file() -> PathBuf {
+    config_dir().join(format!("{PKG_NAME}_backup.json"))
+}
+
+fn config_dir() -> PathBuf {
+    let config_dir = if cfg!(target_os = "macos") {
         let mut home_dir = dirs::home_dir().unwrap();
         home_dir.push(".config");
         home_dir
     } else {
         dirs::config_dir().unwrap()
     };
-    const PKG_NAME: &str = env!("CARGO_PKG_NAME");
-    const FILE_NAME: &str = concat!(env!("CARGO_PKG_NAME"), ".json");
-    file.push(PKG_NAME);
-    file.push(FILE_NAME);
-    file
+    config_dir.join(PKG_NAME)
 }
 
 /// Checks if the configuration file exists.
@@ -139,7 +145,7 @@ fn config_file_exists() -> bool {
 }
 
 /// Writes the application configuration to the config file.
-fn write_config(data: &Application) -> Result<()> {
+pub fn write_config(data: &Application) -> Result<()> {
     let file_path = config_file();
     if !file_path.exists() {
         // The default configuration file path must exist in the parent folder

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -33,8 +33,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         Commands::Edit { id, source, target } => {
             commands::edit(id, source, target)?;
         }
-        Commands::Config => {
-            commands::config();
+        Commands::Config { copy } => {
+            if copy {
+                commands::backup_config_file()?;
+            } else {
+                commands::config();
+            }
         }
     }
     Ok(())

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -7,9 +7,14 @@ use hbackup::commands::{self, Cli, Commands};
 /// Parses command-line arguments and dispatches to the appropriate command handler.
 fn main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
-    let commands = cli
-        .commands
-        .expect("No command provided. Use --help for more information.");
+
+    let commands = match cli.commands {
+        Some(commands) => commands,
+        None => {
+            eprintln!("bk requires at least one command to execute. See 'bk --help' for usage.");
+            std::process::exit(1);
+        }
+    };
 
     match commands {
         Commands::Add { source, target } => {


### PR DESCRIPTION
- add new command: `bk config --copy`
To back up the configuration files
- update release profile settings for optimized builds
- fix: update installation command in README to remove version specification
- fix: improve error handling for missing command in CLI
