### PR TITLE
chore: Bumps version to 0.1.4 for new release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "hbackup"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hbackup"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["asthetik"]
 repository = "https://github.com/asthetik/hbackup"

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -15,6 +15,24 @@ targets=(
 )
 
 for target in "${targets[@]}"; do
+  if [ -e "dist/${target}" ]; then
+    rm -r "dist/${target}"
+  fi
+done
+
+for file in dist/bk-v*.tar.gz; do
+  if [ -e "$file" ]; then
+    rm "$file"
+  fi
+done
+
+for file in dist/bk-v*.zip; do
+  if [ -e "$file" ]; then
+    rm "$file"
+  fi
+done
+
+for target in "${targets[@]}"; do
     echo "==> Building for $target"
     cross build --release --target "$target"
 


### PR DESCRIPTION
- Prepares the project for a new release by incrementing the version.
- Ensures version consistency across manifest and lock files.