### PR TITLE
- chore: Removes leftover build artifacts after packaging

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -63,3 +63,9 @@ for target in "${targets[@]}"; do
         (cd "$out_dir" && zip "../bk-${VERSION}-${archive_target}.zip" "$bin_name")
     fi
 done
+
+for target in "${targets[@]}"; do
+  if [ -e "dist/${target}" ]; then
+    rm -r "dist/${target}"
+  fi
+done


### PR DESCRIPTION
Ensures old build outputs are cleaned up after packaging to prevent clutter and avoid confusion from stale files in the distribution directory.