### PR TITLE
chore: Enables thin LTO for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ path = "src/bin/main.rs"
 
 [profile.release]
 debug = 1
+lto = "thin"
 
 [profile.release-lto]
 inherits = "release"


### PR DESCRIPTION
Adds "thin" link-time optimization (LTO) to the release profile in Cargo.toml to improve build performance and reduce binary size. This change enhances optimization while minimizing compilation overhead compared to full LTO.