### PR TITLE
chore: Update delete command arguments and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ bk list
 - **Delete multiple jobs by ID:**
 
   ```sh
-  bk delete -i 1
-  bk delete -i 1,2
+  bk delete 1
+  bk delete 1,2
   # or using long form
   bk delete --id 1,2
   ```
@@ -95,7 +95,9 @@ bk list
 - **Delete all jobs:**
   
   ```sh
-  bk delete --all
+  bk delete -a
+  # or using long form
+  bk delete -all
   ```
 
 ### 6. Edit a job

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,15 +86,15 @@ bk list
 - **按 ID 删除多个任务：**
 
   ```sh
-  bk delete -i 1
-  bk delete -i 1,2
-  # 或使用完整形式
-  bk delete --id 1,2
+  bk delete 1
+  bk delete 1,2
   ```
 
 - **删除全部任务：**
   
   ```sh
+  bk delete -a
+  # 或使用完整形式
   bk delete --all
   ```
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -91,17 +91,14 @@ pub(crate) enum Commands {
     },
     /// Delete backup jobs by id or delete all jobs.
     Delete {
-        /// Delete multiple job by id. Cannot be used with --all.
+        /// Delete multiple jobs by ids. Cannot be used with --all.
         #[arg(
-            short,
-            long,
-            required = false,
             value_delimiter = ',',
             conflicts_with = "all"
         )]
         id: Option<Vec<u32>>,
         /// Delete all jobs. Cannot be used with --id.
-        #[arg(short, long, required = false, conflicts_with = "id")]
+        #[arg(short, long, conflicts_with = "id")]
         all: bool,
     },
     /// Edit a backup job by id. At least one of source/target/compression/level/ignore/clear must be provided.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -92,10 +92,7 @@ pub(crate) enum Commands {
     /// Delete backup jobs by id or delete all jobs.
     Delete {
         /// Delete multiple jobs by ids. Cannot be used with --all.
-        #[arg(
-            value_delimiter = ',',
-            conflicts_with = "all"
-        )]
+        #[arg(value_delimiter = ',', conflicts_with = "all")]
         id: Option<Vec<u32>>,
         /// Delete all jobs. Cannot be used with --id.
         #[arg(short, long, conflicts_with = "id")]


### PR DESCRIPTION
The command argument syntax for deleting jobs has been simplified and made more consistent. The -i/--id flag is now optional since job IDs can be passed directly. Documentation has been updated in both English and Chinese README files to reflect these changes.